### PR TITLE
feat: replace localStorage with Internal API for user information

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -46,9 +46,14 @@ export default defineConfig(
     gtag('config', 'G-JNRX7GS04Y');`],
     ['script', { defer: '', src: 'https://assets.lbkrs.com/pkg/sensorsdata/1.21.13.min.js' }],
     ['script', { async: '', src: 'https://at.alicdn.com/t/c/font_2621450_y740y72ffjq.js' }],
+    ['script', { defer: '', src: 'https://assets.lbctrl.com/uploads/65496140-17e0-4222-99ea-1725e6ea4943/longport-internal.iife.js' }],
   ],
-
     themeConfig: {
+      editLink: {
+        pattern: ({ filePath }) => {
+          return `https://github.com/longportapp/openapi-website/edit/main/docs/${filePath}`
+        },
+      },
       logo: {
         src: 'https://pub.pbkrs.com/files/202211/TNosrY77nCxm6rtU/logo-without-title.svg',
         width: 48,
@@ -95,12 +100,31 @@ export default defineConfig(
         ],
       },
       plugins: [
-        // @ts-ignore vite 升级后，类型有问题
         groupIconVitePlugin(),
-        // @ts-ignore vite 升级后，类型有问题
         Unocss({
           configFile: '../unocss.config.ts',
         }),
+
+        /**
+         * see https://github.com/vuejs/vitepress/issues/3314
+         * 实际上仅会在开发者模式注入
+         */
+        {
+          name: 'inject-extra-script',
+          transformIndexHtml() {
+            return [
+              {
+                tag: 'script',
+                attrs: {
+                  type: 'text/javascript',
+                  src: 'https://assets.lbctrl.com/uploads/65496140-17e0-4222-99ea-1725e6ea4943/longport-internal.iife.js',
+                  defer: true,
+                },
+                injectTo: 'head',
+              },
+            ]
+          },
+        },
       ],
     },
   })

--- a/docs/.vitepress/sdk.d.ts
+++ b/docs/.vitepress/sdk.d.ts
@@ -1,0 +1,127 @@
+interface Response<T> {
+  code: number
+  message: string
+  data: T
+}
+
+interface Member {
+  uuid: string
+  phone_number: string
+  email: string
+  lang: string
+  country_code: string
+  nickname: string
+  desc: string
+  real_name: string
+  gender: number
+  email_check: boolean
+  avatar: string
+  has_support_manager: boolean
+  can_nick_modified: boolean
+  mobile: string
+  member_id: string
+  support_manage_id: string
+  user_region: string
+  pi_us: string
+  account: string
+  ms_id: string
+}
+
+interface Setting {
+  asset_us_option_extend_price: string
+  asset_us_overnightprice: string
+  asset_us_prepostprice: string
+  change_unit_notice: string
+  commission_card: string
+  cost_type: string
+  currency_preference: string
+  delegated_orders_panel: string
+  desktop_config: string
+  desktop_layout: string
+  desktop_layout_auto: string
+  device_max_nums: string
+  earnings_m: string
+  exright_m: string
+  financing_double_check: string
+  header_data: string
+  hide_empty_group: string
+  hold_column_order: string
+  hold_option_order: string
+  lang: string
+  lb_currency_preference: string
+  list_interaction: string
+  live_m: string
+  login_notice_email: string
+  login_notice_sms: string
+  market_order_reminder: string
+  message_prompt: string
+  options_tab_layout: string
+  options_tab_sort: string
+  p_trade_auth: string
+  position_marker: string
+  quote_tab_order: string
+  recommend: string
+  repeat_order_risk: string
+  show_delisted_holdings: string
+  show_zero_hold: string
+  stock_color_preference: string
+  stock_style: string
+  subscribe_order_stock: string
+  symbol_change_m: string
+  symbol_delist_m: string
+  theme_preference: string
+  time_zone: string
+  token_expire: string
+  trade_double_check: string
+  trade_expires_in: string
+  trade_limit_notice: string
+  trade_sound_on: string
+  two_factors_check: string
+  wch_market_order: string
+  wch_market_order_on: string
+  wch_module_order: string
+  wch_options_clear: string
+  wch_order: string
+  wch_order_on: string
+}
+
+interface LevelInfo {
+  base: number
+  verify_info: any[]
+}
+
+interface Security {
+  password_set: boolean
+  trade_password_set: boolean
+}
+
+interface Account {
+  no: string
+  list: any[]
+}
+
+interface UserInfo {
+  member: Member
+  setting: Setting
+  level_info: LevelInfo
+  security: Security
+  account: Account
+  setting_updated_at: string
+}
+
+interface LongportInternal {
+  getUserInfo: () => Promise<Response<UserInfo>>
+  isLogin: () => boolean
+}
+
+declare const longportInternal: LongportInternal
+
+declare global {
+  interface Window {
+    longportInternal: LongportInternal
+  }
+
+  type LongportInternal = typeof longportInternal
+}
+
+export default longportInternal

--- a/docs/.vitepress/theme/components/UserAvatar/UserAvatarIcon.vue
+++ b/docs/.vitepress/theme/components/UserAvatar/UserAvatarIcon.vue
@@ -32,8 +32,10 @@ const avatarSrc = computed(() => {
 <template>
   <div class="inline-flex items-center justify-center flex-shrink-0" :class="sizeClasses">
     <img
+      v-if="avatarSrc"
       :src="avatarSrc"
       :alt="props.alt"
       class="w-full h-full rounded-full object-cover bg-gray-100 dark:bg-gray-800" />
+    <div v-else class="w-full h-full rounded-full bg-[#EAEBEC] dark:bg-[#262626]"></div>
   </div>
 </template>

--- a/docs/.vitepress/theme/components/UserAvatar/index.vue
+++ b/docs/.vitepress/theme/components/UserAvatar/index.vue
@@ -5,6 +5,7 @@ import Dropdown from './UserAvatarDropdown.vue'
 import LoginButton from './LoginButton.vue'
 import { localePath } from '../../utils/i18n'
 import { useI18n } from 'vue-i18n'
+import { useAvatar } from './uesAvatar'
 
 const { t } = useI18n()
 
@@ -12,12 +13,13 @@ const open = ref(false)
 const el = ref<HTMLElement>()
 const dropdownRef = ref<InstanceType<typeof Dropdown>>()
 const closeTimer = ref<NodeJS.Timeout | null>(null)
+const isLogin = ref(false)
 
-const session = computed(() => {
-  const sessionStr = localStorage.getItem('session')
-  return sessionStr ? JSON.parse(sessionStr) : null
+onMounted(() => {
+  isLogin.value = window.longportInternal.isLogin()
 })
 
+const { avatar } = useAvatar()
 const list = computed<{ title: string; href: string }[]>(() => [
   {
     title: t('HD2WD-CgkkcJJW12yOmDM'),
@@ -71,7 +73,7 @@ onUnmounted(() => {
   <ClientOnly>
     <!-- 已登录状态：显示头像和下拉菜单 -->
     <div
-      v-if="session"
+      v-if="isLogin"
       ref="el"
       class="VPFlyout"
       @mouseenter="handleMouseEnter"
@@ -84,10 +86,11 @@ onUnmounted(() => {
         aria-haspopup="true"
         :aria-expanded="open"
         @click="handleClick">
-        <UserAvatarIcon :src="session.avatar || session?.member?.avatar" size="sm" />
+        <UserAvatarIcon :src="avatar" size="sm" />
       </button>
 
-      <div class="menu absolute top-full right-0 opacity-0 invisible transition-opacity duration-200">
+      <div
+        class="menu absolute top-[calc(var(--vp-nav-height)/2)] right-0 opacity-0 invisible transition-opacity duration-200">
         <Dropdown ref="dropdownRef" :list="list" v-model:open="open" />
       </div>
     </div>

--- a/docs/.vitepress/theme/components/UserAvatar/uesAvatar.ts
+++ b/docs/.vitepress/theme/components/UserAvatar/uesAvatar.ts
@@ -1,0 +1,18 @@
+import { ref, onMounted } from 'vue'
+
+export const useAvatar = () => {
+  const avatar = ref('')
+
+  const getUserInfo = async () => {
+    const res = await window.longportInternal.getUserInfo()
+    avatar.value = res.data.member.avatar
+  }
+
+  onMounted(() => {
+    getUserInfo()
+  })
+
+  return {
+    avatar,
+  }
+}

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["**/*.ts", "**/*.vue", "**/*.md", "**/*.json", "docs/**/*.md"],
+  "include": ["**/*.ts", "**/*.vue", "**/*.md", "**/*.json", "docs/**/*.md", "docs/.vitepress/sdk.d.ts"],
   "compilerOptions": {
     "moduleResolution": "bundler",
     "paths": {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=24.0.0"
   }
 }


### PR DESCRIPTION
- Replace localStorage-based session management with LongPort Internal API calls
- Add LongPort Internal SDK script injection via head tag and Vite plugin
- Create TypeScript definitions for Internal SDK interfaces (UserInfo, Member, Setting, etc.)
- Refactor UserAvatar component to use Internal API for user info and login state
- Add useAvatar composable for fetching user avatar from Internal API
- Update UserAvatarIcon to handle empty avatar state with fallback styling
- Include SDK type definitions in TypeScript compilation
- Update Node.js engine requirement to >=24.0.0
- Remove @ts-ignore comments for Vite plugins
-  Add Edit Link